### PR TITLE
Remove SERVER_* env vars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,6 @@ After cloning the repo, use pip to install dependencies into a virtualenv::
 
 Create a ``.env`` at the root of the repo with a few settings:
 
-- ``SERVER_NAME``: The hostname and port of the Flask app, for example: ``localhost:5000``
-- ``SERVER_PROTOCOL``: The protocol for the Flask server (``http``, ``https``, etc.)
 - ``REDISTOGO_URL``: Redis connection URL, for example ``redis://localhost:6379``
 - ``IIIF_SERVICE_URL``: URL to the IIIF service. This should be the full URL, for example: ``http://example.com/iiif/2``
 

--- a/app.json
+++ b/app.json
@@ -1,8 +1,6 @@
 {
     "name": "TryIIIF",
     "env": {
-        "SERVER_NAME": {"required": true},
-        "SERVER_PROTOCOL": {"required": true},
         "REDISTOGO_URL": {"required": true},
         "IIIF_SERVICE_URL": {"required": true}
     },

--- a/tryiiif/config.py
+++ b/tryiiif/config.py
@@ -7,7 +7,5 @@ class Default(object):
 
 
 class Heroku(Default):
-    SERVER_NAME = os.environ['SERVER_NAME']
-    SERVER_PROTOCOL = os.environ['SERVER_PROTOCOL']
     REDISTOGO_URL = os.environ['REDISTOGO_URL']
     IIIF_SERVICE_URL = os.environ['IIIF_SERVICE_URL']

--- a/tryiiif/home/__init__.py
+++ b/tryiiif/home/__init__.py
@@ -6,6 +6,7 @@ import uuid
 from flask import (Blueprint, current_app, json, render_template, request,
                    url_for)
 import requests
+from werkzeug.urls import url_parse
 
 from tryiiif.extensions import rc
 
@@ -15,6 +16,9 @@ home = Blueprint('home', __name__)
 
 @home.route('/', methods=['GET', 'POST'])
 def index():
+    parts = url_parse(request.url_root)
+    current_app.config.update(SERVER_NAME=parts.netloc,
+                              SERVER_PROTOCOL=parts.scheme)
     if request.method == 'POST':
         url = request.form['url']
         name = request.form.get('title', url)


### PR DESCRIPTION
We need to dynamically determine the SERVER_NAME var in order to make
this work with Heroku's review apps.
