### PR TITLE
Issue #21

### DIFF
--- a/tests/test_iiif.py
+++ b/tests/test_iiif.py
@@ -18,6 +18,12 @@ def testPostWithoutURLIncludesWarning(testapp):
     assert 'A URL to an image is required.' in r
 
 
+def testPostToNonexistentUrlIncludesWarning(testapp, iiif_server):
+    url = 'http://{}:{}/404'.format(*iiif_server)
+    r = testapp.post('/', {'url': url, 'submit': 'uv'})
+    assert "It looks like there&#39;s nothing there." in r
+
+
 def testPostWithValidFieldsToUVRedirectsToUV(testapp):
     url = 'https://dome.mit.edu/bitstream/handle/1721.3/176472/249875_cp.jpg'
     res = testapp.post('/', dict(title='whatevs', url=url, submit='uv'))

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 passenv=REDISTOGO_URL
-commands = py.test tests --cov=tryiiif {posargs}
+commands = py.test --cov=tryiiif {posargs}
 deps =
     webtest
     pytest

--- a/tryiiif/home/__init__.py
+++ b/tryiiif/home/__init__.py
@@ -46,11 +46,11 @@ def index():
         except:
             hr = requests.head(url)
             if 400 <= hr.status_code < 500:
-                flash('It looks like there\'s nothing there. Please double'
+                flash('It looks like there\'s nothing there. Please double '
                       'check your URL.', 'danger')
                 return render_template('index.html')
             elif not hr.headers.get('content-type', '').startswith('image'):
-                flash('That doesn\'t look like an image. Please double check'
+                flash('That doesn\'t look like an image. Please double check '
                       'your URL.', 'danger')
                 return render_template('index.html')
             else:

--- a/tryiiif/home/__init__.py
+++ b/tryiiif/home/__init__.py
@@ -41,6 +41,23 @@ def index():
         b64url = b64safe(url)
         iiif_url = current_app.config.get('IIIF_SERVICE_URL').rstrip('/')
         res = requests.get('{}/{}/info.json'.format(iiif_url, b64url))
+        try:
+            res.raise_for_status()
+        except:
+            hr = requests.head(url)
+            if 400 <= hr.status_code < 500:
+                flash('It looks like there\'s nothing there. Please double'
+                      'check your URL.', 'danger')
+                return render_template('index.html')
+            elif not hr.headers.get('content-type', '').startswith('image'):
+                flash('That doesn\'t look like an image. Please double check'
+                      'your URL.', 'danger')
+                return render_template('index.html')
+            else:
+                flash('Something went wrong. Please try again later.',
+                      'danger')
+                return render_template('index.html')
+
         info = res.json()
         manifest = make_manifest(b64url, url, b64url, name, info['height'],
                                  info['width'])


### PR DESCRIPTION
Closes #21. This attempts to address two specific cases of errors when
the user posts a URL:
- the image is not there or not accessible
- the link does not appear to be an image

A default error message is generated for everything else.
